### PR TITLE
Switch Cauldron API

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -86,15 +86,19 @@ export default function TokenDataPage() {
         }
         const fixedPrice = parseFloat(bchPrice.toFixed(2));
 
-        const dataPromises = tokenIds.map((category) =>
-          getTokenData(category, fixedPrice)
-        );
+        const dataPromises = tokenIds.map(async (category) => {
+          try {
+            return await getTokenData(category, fixedPrice);
+          } catch (e) {
+            return Promise.resolve(null);
+          }
+        });
         const results = await Promise.all(dataPromises);
-        const allTokenData = results.flat();
+        const allTokenData: TokenData[] = results.flat().filter((d): d is TokenData => d !== null);
         setTokenData(allTokenData);
       } catch (error) {
         if (error instanceof Error) {
-          setError(error.message);
+          setError(`Error fetching token data: ${error.message}`);
         } else {
           setError("An unexpected error occurred");
         }

--- a/app/providers/bchpriceclientprovider.tsx
+++ b/app/providers/bchpriceclientprovider.tsx
@@ -36,6 +36,13 @@ export const BCHPriceProvider: React.FC<{ children: ReactNode }> = ({
       try {
         const response = await fetch("/api/bchPrice");
         const data = await response.json();
+        if (data.error) {
+          throw Error(data.error);
+        }
+        if (data.USD === undefined) {
+          console.log("internal bch price API response:", data);
+          throw Error("BCH price not set")
+        }
         setBchPrice(data.USD);
       } catch (error) {
         console.error("Error fetching BCH price from internal API:", error);


### PR DESCRIPTION
Use open source cauldron indexer API rather than (deprecated) electrum
wrapper API.

Includes some bug fixes for issues I ran into. Not sure if you want 404c5c6c906cbcdb537cfd0fe3600d7890339399, can remove it from the PR if preferred.